### PR TITLE
fix: handle setup.sh failure when only CommandLineTools installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Fix setup.sh failing when only Xcode CommandLineTools is installed (#3)
+
 ### Added
 - Initial iOS app implementation (#1)
 - Browse 10 DoubleZero account types: Exchanges, Contributors, Locations, Devices, Links, Users, Multicast Groups, Tenants, Access Passes, Reservations

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 echo "gm00 Development Setup"
 echo "======================"
 
-# Check Xcode
-if ! command -v xcodebuild &> /dev/null; then
-    echo "ERROR: Xcode is not installed. Install from the App Store."
+# Check that Xcode (not just CommandLineTools) is installed and functional
+if ! xcodebuild -version &> /dev/null; then
+    echo "ERROR: Xcode is not installed or not properly configured."
+    echo ""
+    echo "The active developer directory may point to CommandLineTools instead of Xcode."
+    echo "Install Xcode from the App Store, then run:"
+    echo "  sudo xcode-select -s /Applications/Xcode.app/Contents/Developer"
     exit 1
 fi
 
@@ -15,7 +19,7 @@ echo "Found: $XCODE_VERSION"
 
 # Check minimum version (Xcode 16+)
 MAJOR=$(echo "$XCODE_VERSION" | grep -o '[0-9]*' | head -1)
-if [ "$MAJOR" -lt 16 ]; then
+if [ -z "$MAJOR" ] || [ "$MAJOR" -lt 16 ]; then
     echo "ERROR: Xcode 16+ required. Found: $XCODE_VERSION"
     exit 1
 fi


### PR DESCRIPTION
## Summary of Changes
* Fix scripts/setup.sh failing when only Xcode CommandLineTools (not full Xcode) is installed
* Replace command -v xcodebuild with xcodebuild -version functional check to properly detect whether full Xcode is available
* Add empty-string guard before integer comparison to handle cases where version parsing returns empty
* Add set -uo pipefail for stricter shell error handling
* Improve error message with actionable xcode-select -s fix instructions
* Addresses #3

## Testing Verification
* Script syntax verified with bash -n
* Verified diff is minimal and focused (2 files, 12 insertions, 5 deletions)
* Architecture review: 0 critical, 0 high (1 medium, 3 low)
* Security review: 0 critical, 0 high, 0 medium (2 low - both positive observations)
