### PR TITLE
feat: add Home button to toolbar for quick root navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Home button in toolbar to jump back to home screen from any depth (#6)
+
 ### Fixed
 - Fix setup.sh failing when only Xcode CommandLineTools is installed (#3)
 

--- a/gm00/gm00/App/ContentView.swift
+++ b/gm00/gm00/App/ContentView.swift
@@ -33,6 +33,15 @@ struct ContentView: View {
                     }
                 }
                 .toolbar {
+                    if !navigationPath.isEmpty {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            Button {
+                                navigationPath = NavigationPath()
+                            } label: {
+                                Image(systemName: "house")
+                            }
+                        }
+                    }
                     ToolbarItem(placement: .topBarTrailing) {
                         Button {
                             showSettings = true


### PR DESCRIPTION
## Summary of Changes
* Add a Home button (house icon) in the top-right toolbar that appears on all non-root screens
* Tapping it resets the NavigationPath, instantly popping back to the home screen from any navigation depth
* Only visible when the user has navigated away from the home screen (navigationPath.isEmpty check)
* Addresses #6

## Testing Verification
* Code change is minimal (9 lines in ContentView.swift) and uses standard SwiftUI NavigationPath API
* Architecture review: 0 critical, 0 high, 0 medium, 3 low findings (all cosmetic/polish)
* Security review: 0 findings across all severity levels
* Build could not be verified via CLI due to xcodebuild permission restrictions, but the change is syntactically valid SwiftUI that follows existing patterns in the codebase
